### PR TITLE
Snbt fixes

### DIFF
--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/CompoundTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/CompoundTag.java
@@ -177,6 +177,14 @@ public class CompoundTag extends Tag implements Iterable<Tag> {
     @Override
     public void destringify(StringifiedNBTReader in) throws IOException {
         in.readSkipWhitespace();
+        
+        //Check for empty compound
+        in.skipWhitespace();
+        if(in.lookAhead(0) == '}') {
+            in.read();
+            return;
+        }
+        
         while(true) {
             String tagName = "";
             if((tagName += in.readSkipWhitespace()).equals("\"")) {

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/DoubleTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/DoubleTag.java
@@ -3,6 +3,7 @@ package com.github.steveice10.opennbt.tag.builtin;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.text.DecimalFormat;
 
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTReader;
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTWriter;
@@ -67,7 +68,8 @@ public class DoubleTag extends Tag {
     @Override
     public void stringify(StringifiedNBTWriter out, boolean linebreak, int depth) throws IOException {
         StringBuilder sb = new StringBuilder();
-        sb.append(value);
+        DecimalFormat df = new DecimalFormat("#.#");
+        sb.append(df.format(value));
         sb.append('d');
         out.append(sb.toString());
     }

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/FloatTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/FloatTag.java
@@ -3,6 +3,7 @@ package com.github.steveice10.opennbt.tag.builtin;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.text.DecimalFormat;
 
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTReader;
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTWriter;
@@ -67,7 +68,8 @@ public class FloatTag extends Tag {
     @Override
     public void stringify(StringifiedNBTWriter out, boolean linebreak, int depth) throws IOException {
         StringBuilder sb = new StringBuilder();
-        sb.append(value);
+        DecimalFormat df = new DecimalFormat("#.#");
+        sb.append(df.format(value));
         sb.append('f');
         out.append(sb.toString());
     }

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/ListTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/ListTag.java
@@ -194,6 +194,14 @@ public class ListTag extends Tag implements Iterable<Tag> {
     @Override
     public void destringify(StringifiedNBTReader in) throws IOException {
         in.readSkipWhitespace();
+        
+        //Check for empty list
+        in.skipWhitespace();
+        if(in.lookAhead(0) == ']') {
+            in.read();
+            return;
+        }
+        
         while(true) {
             add(in.readNextTag(""));
 

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/StringTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/StringTag.java
@@ -60,7 +60,9 @@ public class StringTag extends Tag {
     @Override
     public void destringify(StringifiedNBTReader in) throws IOException {
         String s = in.readNextSingleValueString();
-        if(s.charAt(0) == '"') {
+        if(s.length() == 0) {
+            value = s;
+        } else if(s.charAt(0) == '"') {
             value = s.substring(1, s.length() - 1).replaceAll("\\\\\"", "\"");
         } else if(s.charAt(0) == '\'') {
             value = s.substring(1, s.length() - 1).replaceAll("\\\\\'", "'");

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/custom/DoubleArrayTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/custom/DoubleArrayTag.java
@@ -3,6 +3,7 @@ package com.github.steveice10.opennbt.tag.builtin.custom;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.text.DecimalFormat;
 
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTReader;
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTWriter;
@@ -110,8 +111,9 @@ public class DoubleArrayTag extends Tag {
     @Override
     public void stringify(StringifiedNBTWriter out, boolean linebreak, int depth) throws IOException {
         StringBuilder sb = new StringBuilder("[D; ");
+        DecimalFormat df = new DecimalFormat("#.#");
         for(double b : value) {
-            sb.append(b);
+            sb.append(df.format(b));
             sb.append(',');
             sb.append(' ');
         }

--- a/src/main/java/com/github/steveice10/opennbt/tag/builtin/custom/FloatArrayTag.java
+++ b/src/main/java/com/github/steveice10/opennbt/tag/builtin/custom/FloatArrayTag.java
@@ -3,6 +3,7 @@ package com.github.steveice10.opennbt.tag.builtin.custom;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.text.DecimalFormat;
 
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTReader;
 import com.github.steveice10.opennbt.SNBTIO.StringifiedNBTWriter;
@@ -110,8 +111,9 @@ public class FloatArrayTag extends Tag {
     @Override
     public void stringify(StringifiedNBTWriter out, boolean linebreak, int depth) throws IOException {
         StringBuilder sb = new StringBuilder("[F; ");
+        DecimalFormat df = new DecimalFormat("#.#");
         for(float b : value) {
-            sb.append(b);
+            sb.append(df.format(b));
             sb.append(',');
             sb.append(' ');
         }


### PR DESCRIPTION
Fixes issue with the SNBT reader when reading empty compound, list and string tags. Fixes issue #24.
Also fixes number formatting of float and double tags when writing SNBT to be in decimal format, instead of scientific format.